### PR TITLE
Adds timeout to `opener.open`

### DIFF
--- a/wgetter.py
+++ b/wgetter.py
@@ -269,7 +269,7 @@ def download(link, outdir='.', chunk_size=4096):
 
     try:
         opener = ulib.build_opener(ulib.HTTPCookieProcessor(cj))
-        url = opener.open(link)
+        url = opener.open(link, timeout=30)
         fh = open(tmpfile, mode='wb')
 
         headers = url.info()


### PR DESCRIPTION
This is an operation that hangs, adding a timeout prevents this hang.